### PR TITLE
await for async executeCommand

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,7 @@ function activate(context) {
   context.subscriptions.push(disposable);
 }
 
-function foldCommand() {
+async function foldCommand() {
   const methodsToFold = vscode.workspace
     .getConfiguration('foldIt')
     .get(METHODS_TO_FOLD_CONFIG_NAME);
@@ -16,19 +16,24 @@ function foldCommand() {
 
   const initialPosition = editor.selection.active.line;
 
-  methodsToFold.forEach(l => foldByMethodName(editor, l));
+  for (const m of methodsToFold) {
+    await foldByMethodName(editor, m)
+  }
+
   moveCursorTo(editor, initialPosition);
 }
 
-function foldByMethodName(editor, methodName) {
+async function foldByMethodName(editor, methodName) {
   const itLines = findLineNumbersByString(editor.document, methodName);
 
-  itLines.forEach(l => foldLine(editor, l));
+  for (const l of itLines) {
+    await foldLine(editor, l);
+  }
 }
 
-function foldLine(editor, lineNum) {
+async function foldLine(editor, lineNum) {
   moveCursorTo(editor, lineNum);
-  vscode.commands.executeCommand('editor.fold');
+  await vscode.commands.executeCommand('editor.fold');
 }
 
 function findLineNumbersByString(doc, specMethodName) {


### PR DESCRIPTION
Hi @alexpusch, cool extension!

Unfortunately it doesn't work (at least for me?)

I took a look at the code and it seems there is a race condition. `executeCommand` in asynchronous, and if you don't wait for it to finish before moving on, the cursor is moved away from where it needs to be. This causes the command to run in the original location and therefore nothing happens.

The solution is simple, just make the calls serial